### PR TITLE
Add Scelta include folder to the header-only target.

### DIFF
--- a/cmake/impl/vc_install.cmake
+++ b/cmake/impl/vc_install.cmake
@@ -18,6 +18,7 @@ macro(vrm_cmake_header_only_install target_name file_list src_dir dest_dir)
     # all the source files to it.
     add_library(${target_name} INTERFACE)
     target_sources(${target_name} INTERFACE ${file_list})
+    target_include_directories(${target_name} INTERFACE ${src_dir})
 
     # In order to allow IDEs such as "Qt Creator" to correctly display the
     # files that compose the header-only library, a custom target needs

--- a/cmake/impl/vc_log.cmake
+++ b/cmake/impl/vc_log.cmake
@@ -6,6 +6,6 @@
 # Message with "[vrm_cmake]" prefix.
 macro(vrm_cmake_message x)
 #{
-    message("[vrm_cmake] ${x}")
+    message(STATUS "[vrm_cmake] ${x}")
 #}
 endmacro()


### PR DESCRIPTION
This will allow a parent project who depends on the scelta
headers target to see scelta's include folder.

Also changes the logging message to use `STATUS` which sends
the logging to stdout like standard cmake messages (as opposed
to standard error).

Tested with CMake 3.13.1.